### PR TITLE
Change default URLs to localhost

### DIFF
--- a/api/kafka.py
+++ b/api/kafka.py
@@ -5,7 +5,7 @@ from api.pricewars_base_api import PricewarsBaseApi
 
 
 class Kafka(PricewarsBaseApi):
-    DEFAULT_URL = 'http://kafka-reverse-proxy:8001'
+    DEFAULT_URL = 'http://localhost:8001'
 
     def __init__(self, token: str, host: str = DEFAULT_URL, debug: bool = False):
         super().__init__(token, host, debug)

--- a/api/marketplace.py
+++ b/api/marketplace.py
@@ -10,7 +10,7 @@ from models import Offer, MerchantRegisterResponse
 
 
 class Marketplace(PricewarsBaseApi):
-    DEFAULT_URL = 'http://marketplace:8080'
+    DEFAULT_URL = 'http://localhost:8080'
 
     def __init__(self, token: Optional[str] = None, host: str = DEFAULT_URL, debug: bool = False):
         super().__init__(token, host, debug)

--- a/api/producer.py
+++ b/api/producer.py
@@ -7,7 +7,7 @@ from models import Order
 
 
 class Producer(PricewarsBaseApi):
-    DEFAULT_URL = 'http://producer:3050'
+    DEFAULT_URL = 'http://localhost:3050'
 
     def __init__(self, token: str, host: str = DEFAULT_URL, debug: bool = False):
         super().__init__(token, host, debug)


### PR DESCRIPTION
The new default is for connecting the merchant to a locally running pricewars platform (e.g. a local docker setup).